### PR TITLE
Learning TypeScript. Advanced Types. Intersection Types

### DIFF
--- a/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.test.ts
+++ b/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.test.ts
@@ -1,0 +1,14 @@
+import { intersect } from '.';
+
+describe(intersect.name, () => {
+    it('should contain properties only from first and second objects', () => {
+        const obj1 = { a: 1 };
+        const obj2 = { a: 2, b: 2 };
+        const intersection = intersect(obj1, obj2);
+        expect(intersection).toEqual({ a: 1 });
+        const obj3 = { c: 3, d: 4 };
+        const intersection2 = intersect(obj2, obj3);
+        expect(intersection2).toEqual({});
+    });
+
+});

--- a/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.test.ts
+++ b/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.test.ts
@@ -11,4 +11,35 @@ describe(intersect.name, () => {
         expect(intersection2).toEqual({});
     });
 
+    it('should work correctly with empty objects', () => {
+        const obj1 = {};
+        const obj2 = { a: Math.random(), b: Math.random() };
+        const intersection3 = intersect(obj1, obj2);
+        expect(intersection3).toEqual({});
+        const intersection4 = intersect(obj2, obj1);
+        expect(intersection4).toEqual({});
+        const intersection5 = intersect(obj1, obj1);
+        expect(intersection5).toEqual({});
+    });
+});
+
+it.each([
+    [{ a: 1 }, { a: 2 }, { a: 1 }],
+    [
+        { a: 1, b: 2 },
+        { a: 2, b: 3 },
+        { a: 1, b: 2 },
+    ],
+    [
+        { a: 1, b: 2 },
+        { a: 2, b: 3, c: 4 },
+        { a: 1, b: 2 },
+    ],
+    [
+        { a: 1, b: 2 },
+        { a: 2, b: 3, c: 4, d: 5 },
+        { a: 1, b: 2 },
+    ],
+])('should return intersection of %p and %p as %p', (obj1, obj2, expected) => {
+    expect(intersect(obj1, obj2)).toEqual(expected);
 });

--- a/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.ts
+++ b/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.ts
@@ -1,0 +1,49 @@
+/*
+https://www.codewars.com/kata/5916c87540ef95d8e1000007
+
+An intersection type combines multiple types into one. This allows you to add together existing types to get a single type
+that has all the features you need. For example, Person & Serializable & Loggable is a Person and Serializable and Loggable.
+That means an object of this type will have all members of all three types.
+
+You will mostly see intersection types used for mixins and other concepts that don’t fit in the classic object-oriented mold.
+(There are a lot of these in JavaScript!) Here’s a simple example that shows how to create a mixin:
+
+function extend<T, U>(first: T, second: U): T & U {
+    let result = <T & U>{};
+    for (let id in first) {
+        (<any>result)[id] = (<any>first)[id];
+    }
+    for (let id in second) {
+        if (!result.hasOwnProperty(id)) {
+            (<any>result)[id] = (<any>second)[id];
+        }
+    }
+    return result;
+}
+
+class Person {
+    constructor(public name: string) { }
+}
+interface Loggable {
+    log(): void;
+}
+class ConsoleLogger implements Loggable {
+    log() {
+        // ...
+    }
+}
+var jim = extend(new Person("Jim"), new ConsoleLogger());
+var n = jim.name;
+jim.log();
+Task
+In the example above you can see that extends function returns T & U which should correspond to intersection of types T and U.
+ But in fact it returns object containing all properties from T mixed with additional properties from U.
+
+Your task is to create function intersect which returns object with properties that are present simultaneously in T and U.
+*/
+
+export function intersect<T, U>(first: T, second: U): T & U {
+    const result = <T & U>{};
+    // TODO:
+    return result;
+}

--- a/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.ts
+++ b/src/learningTypescript/part03_advanced_types/part9_intersection-types/index.ts
@@ -45,5 +45,11 @@ Your task is to create function intersect which returns object with properties t
 export function intersect<T, U>(first: T, second: U): T & U {
     const result = <T & U>{};
     // TODO:
+    Object.keys(first).forEach((key) => {
+        if (second[key as keyof U]) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (<any>result)[key] = (<any>first)[key];
+        }
+    });
     return result;
 }


### PR DESCRIPTION
# [Learning TypeScript. Advanced Types. Intersection Types](https://www.codewars.com/kata/5916c87540ef95d8e1000007)

## Notes
one of the solutions mentioned that this is not good practice, intersection types should include everything from both original items

## Checklist
- [x] url and description in `index` file (see below)
- [x] tested
- [x] PR labeled with difficulty


#### Example
```typescript
/*
https://www.codewars.com/kata/<some numbers>

Write function that meets these requirements...
 */
```
