### PR TITLE
Esolang Interpreters 2 - Custom Smallfuck Interpreter

### DIFF
--- a/src/esolangInturpreters/part2/SmallfuckInterpreter.ts
+++ b/src/esolangInturpreters/part2/SmallfuckInterpreter.ts
@@ -1,31 +1,17 @@
-type MoveLeftOrRight = '>' | '<';
-type Brackets = '[' | ']';
-type Command = MoveLeftOrRight | '*' | Brackets;
-type Bit = 0 | 1;
-
 export class SmallfuckInterpreter {
-    code: Command[];
-
-    tape: Bit[];
-
     private pointer = 0;
 
     private codeIndex = 0;
 
     private COMMANDS = new Map([
-        ['>', () => this.moveRight()],
         ['<', () => this.moveLeft()],
+        ['>', () => this.moveRight()],
         ['*', () => this.flipBit()],
         ['[', () => this.findClosingBracket()],
         [']', () => this.findOpeningBracket()],
     ]);
 
-    constructor(code: string, tape: string) {
-        // code may contain non-command characters. Your interpreter should simply ignore any non-command characters.
-        this.code = this.validateCode(code.split(''));
-        // You may assume that all input strings for tape will be non-empty and will only contain "0"s and "1"s.
-        this.tape = tape.split('').map(Number) as Bit[];
-    }
+    constructor(private code: string, private tape: string) {}
 
     interpret() {
         while (this.isCodeIndexValid() && this.isPointerValid()) {
@@ -33,47 +19,44 @@ export class SmallfuckInterpreter {
             this.codeIndex += 1;
         }
 
-        return this.tape.join('');
+        return this.tape;
     }
 
-    // > - Move pointer to the right (by 1 cell)
+    private getCurrentBit() {
+        return this.tape[this.pointer];
+    }
+
     private moveRight() {
         this.pointer += 1;
     }
 
-    // < - Move pointer to the left (by 1 cell)
     private moveLeft() {
         this.pointer -= 1;
     }
 
-    // * - Flip the bit at the current cell
     private flipBit() {
-        this.tape[this.pointer] = this.tape[this.pointer] === 0 ? 1 : 0;
+        const tapeArray = this.tape.split('');
+
+        tapeArray[this.pointer] = tapeArray[this.pointer] === '0' ? '1' : '0';
+
+        this.tape = tapeArray.join('');
     }
 
-    // [ - Jump past matching ] if value at current cell is 0
     private findClosingBracket() {
-        if (this.tape[this.pointer] === 0) {
+        if (this.getCurrentBit() === '0') {
             const closingBracketIndex = this.code.indexOf(']', this.codeIndex);
             this.codeIndex = closingBracketIndex + 1;
         }
     }
 
-    // ] - Jump back to matching [ (if value at current cell is nonzero)
     private findOpeningBracket() {
-        if (this.tape[this.pointer] === 1) {
+        if (this.getCurrentBit() === '1') {
             const openingBracketIndex = this.code.lastIndexOf(
                 '[',
                 this.codeIndex,
             );
             this.codeIndex = openingBracketIndex;
         }
-    }
-
-    private validateCode(code: string[]) {
-        return code.filter((command) =>
-            this.COMMANDS.has(command),
-        ) as Command[];
     }
 
     private isCodeIndexValid() {

--- a/src/esolangInturpreters/part2/SmallfuckInterpreter.ts
+++ b/src/esolangInturpreters/part2/SmallfuckInterpreter.ts
@@ -1,0 +1,86 @@
+type MoveLeftOrRight = '>' | '<';
+type Brackets = '[' | ']';
+type Command = MoveLeftOrRight | '*' | Brackets;
+type Bit = 0 | 1;
+
+export class SmallfuckInterpreter {
+    code: Command[];
+
+    tape: Bit[];
+
+    private pointer = 0;
+
+    private codeIndex = 0;
+
+    private COMMANDS = new Map([
+        ['>', () => this.moveRight()],
+        ['<', () => this.moveLeft()],
+        ['*', () => this.flipBit()],
+        ['[', () => this.findClosingBracket()],
+        [']', () => this.findOpeningBracket()],
+    ]);
+
+    constructor(code: string, tape: string) {
+        // code may contain non-command characters. Your interpreter should simply ignore any non-command characters.
+        this.code = this.validateCode(code.split(''));
+        // You may assume that all input strings for tape will be non-empty and will only contain "0"s and "1"s.
+        this.tape = tape.split('').map(Number) as Bit[];
+    }
+
+    interpret() {
+        while (this.isCodeIndexValid() && this.isPointerValid()) {
+            this.COMMANDS.get(this.code[this.codeIndex])?.();
+            this.codeIndex += 1;
+        }
+
+        return this.tape.join('');
+    }
+
+    // > - Move pointer to the right (by 1 cell)
+    private moveRight() {
+        this.pointer += 1;
+    }
+
+    // < - Move pointer to the left (by 1 cell)
+    private moveLeft() {
+        this.pointer -= 1;
+    }
+
+    // * - Flip the bit at the current cell
+    private flipBit() {
+        this.tape[this.pointer] = this.tape[this.pointer] === 0 ? 1 : 0;
+    }
+
+    // [ - Jump past matching ] if value at current cell is 0
+    private findClosingBracket() {
+        if (this.tape[this.pointer] === 0) {
+            const closingBracketIndex = this.code.indexOf(']', this.codeIndex);
+            this.codeIndex = closingBracketIndex + 1;
+        }
+    }
+
+    // ] - Jump back to matching [ (if value at current cell is nonzero)
+    private findOpeningBracket() {
+        if (this.tape[this.pointer] === 1) {
+            const openingBracketIndex = this.code.lastIndexOf(
+                '[',
+                this.codeIndex,
+            );
+            this.codeIndex = openingBracketIndex;
+        }
+    }
+
+    private validateCode(code: string[]) {
+        return code.filter((command) =>
+            this.COMMANDS.has(command),
+        ) as Command[];
+    }
+
+    private isCodeIndexValid() {
+        return this.codeIndex >= 0 && this.codeIndex < this.code.length;
+    }
+
+    private isPointerValid() {
+        return this.pointer >= 0 && this.pointer < this.tape.length;
+    }
+}

--- a/src/esolangInturpreters/part2/index.test.ts
+++ b/src/esolangInturpreters/part2/index.test.ts
@@ -1,0 +1,14 @@
+import { interpreter } from '.';
+
+describe(interpreter.name, () => {
+    it.each([
+        ['*', '00101100', '10101100'],
+        ['>*>*', '00101100', '01001100'],
+        ['*>*>*>*>*>*>*>*', '00101100', '11010011'],
+        ['*>*>>*>>>*>*', '00101100', '11111111'],
+        ['>>>>>*<*<<*', '00101100', '00000000'],
+    ])(
+        'should take code: "%s" and tape: "%s" and return "%s" ',
+        (code, tape, output) => expect(interpreter(code, tape)).toBe(output),
+    );
+});

--- a/src/esolangInturpreters/part2/index.test.ts
+++ b/src/esolangInturpreters/part2/index.test.ts
@@ -1,14 +1,90 @@
 import { interpreter } from '.';
 
 describe(interpreter.name, () => {
-    it.each([
-        ['*', '00101100', '10101100'],
-        ['>*>*', '00101100', '01001100'],
-        ['*>*>*>*>*>*>*>*', '00101100', '11010011'],
-        ['*>*>>*>>>*>*', '00101100', '11111111'],
-        ['>>>>>*<*<<*', '00101100', '00000000'],
-    ])(
-        'should take code: "%s" and tape: "%s" and return "%s" ',
-        (code, tape, output) => expect(interpreter(code, tape)).toBe(output),
-    );
+    const testName = 'should take code: "%s" and tape: "%s" and return "%s"';
+    const expectedResult = (code: string, tape: string, output: string) =>
+        expect(interpreter(code, tape)).toBe(output);
+
+    describe('example test cases', () => {
+        it.each([
+            ['*', '00101100', '10101100'],
+            ['>*>*', '00101100', '01001100'],
+            ['*>*>*>*>*>*>*>*', '00101100', '11010011'],
+            ['*>*>>*>>>*>*', '00101100', '11111111'],
+            ['>>>>>*<*<<*', '00101100', '00000000'],
+        ])(testName, (code, tape, output) =>
+            expectedResult(code, tape, output),
+        );
+    });
+
+    describe('non-command characters', () => {
+        it.each([
+            ['iwmlis *!BOSS 333 ^v$#@', '00101100', '10101100'],
+            ['>*>*;;;.!.,+-++--!!-!!!-', '00101100', '01001100'],
+            [
+                `    *  >
+                *           >
+
+            *>*lskdfjsdklfj>*;;+--+--+++--+-+-  lskjfiom,x
+            >*sdfsdf>sdfsfsdfsdfwervbnbvn*,.,.,,.,.  >
+
+
+            *`,
+                '00101100',
+                '11010011',
+            ],
+            [
+                '*,,...,..,..++-->++++-*>--+>*>+++->>..,+-,*>*',
+                '00101100',
+                '11111111',
+            ],
+            ['>>nssewww>>wwess>*<nnn*<<ee*', '00101100', '00000000'],
+        ])(testName, (code, tape, output) =>
+            expectedResult(code, tape, output),
+        );
+    });
+
+    describe('if the pointer goes out of bounds', () => {
+        it.each([
+            [
+                '*>>>*>*>>*>>>>>>>*>*>*>*>>>**>>**',
+                '0000000000000000',
+                '1001101000000111',
+            ],
+            [
+                '<<<*>*>*>*>*>>>*>>>>>*>*',
+                '0000000000000000',
+                '0000000000000000',
+            ],
+            [
+                '*>*>*>>>*>>>>>*<<<<<<<<<<<<<<<<<<<<<*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*>*>*',
+                '11111111111111111111111111111111',
+                '00011011110111111111111111111111',
+            ],
+            ['>>*>*>*<<*<*<<*>*', '1101', '1110'],
+        ])(testName, (code, tape, output) =>
+            expectedResult(code, tape, output),
+        );
+    });
+
+    describe('simple and nested loops', () => {
+        it.each([
+            ['*[>*]', '0'.repeat(256), '1'.repeat(256)],
+            ['[>*]', '0'.repeat(256), '0'.repeat(256)],
+            [
+                '*>*>>>*>*>>>>>*>[>*]',
+                '0'.repeat(256),
+                `11001100001${'0'.repeat(245)}`,
+            ],
+            [
+                '*>*>>>*>*>>>>>*[>*]',
+                '0'.repeat(256),
+                `11001100001${'1'.repeat(245)}`,
+            ],
+            ['*[>[*]]', '0'.repeat(256), `1${'0'.repeat(255)}`],
+            ['*[>[*]]', '1'.repeat(256), `0${'1'.repeat(255)}`],
+        ])(testName, (code, tape, output) =>
+            expectedResult(code, tape, output),
+        );
+    });
 });

--- a/src/esolangInturpreters/part2/index.ts
+++ b/src/esolangInturpreters/part2/index.ts
@@ -45,20 +45,25 @@ For example, if the tape in your interpreter ends up being [1, 1, 1, 1, 1] then 
 NOTE: The pointer of the interpreter always starts from the first (leftmost) cell of the tape, same as in Brainfuck.
 */
 
-type MoveLeftOrRight = '>' | '<';
-type Brackets = '[' | ']';
-type Code = MoveLeftOrRight | '*' | Brackets;
-type Bit = '0' | '1';
+import { SmallfuckInterpreter } from './SmallfuckInterpreter';
 
-const isValidIndex = (index: number, array: unknown[]) =>
-    index >= 0 && index < array.length;
+// type MoveLeftOrRight = '>' | '<';
+// type Brackets = '[' | ']';
+// type Code = MoveLeftOrRight | '*' | Brackets;
+// type Bit = '0' | '1';
 
-const flipBit = (bit: Bit) => (bit === '0' ? '1' : '0');
-const moveLeftOrRight = (command: MoveLeftOrRight) =>
-    command === '>' ? 1 : -1;
+// const isValidIndex = (index: number, array: unknown[]) =>
+//     index >= 0 && index < array.length;
+
+// const flipBit = (bit: Bit) => (bit === '0' ? '1' : '0');
+// const moveLeftOrRight = (command: MoveLeftOrRight) =>
+//     command === '>' ? 1 : -1;
 
 export function interpreter(code: string, tape: string): string {
-    const codeArray = code.split('');
+    const smallfuckInterpreter = new SmallfuckInterpreter(code, tape);
+
+    return smallfuckInterpreter.interpret();
+    /* const codeArray = code.split('');
     // You may assume that all input strings for tape will be non-empty and will only contain "0"s and "1"s.
     const tapeArray = tape.split('') as Bit[];
 
@@ -120,5 +125,5 @@ export function interpreter(code: string, tape: string): string {
         codeIndex += 1;
     }
 
-    return tapeArray.join('');
+    return tapeArray.join(''); */
 }

--- a/src/esolangInturpreters/part2/index.ts
+++ b/src/esolangInturpreters/part2/index.ts
@@ -46,5 +46,41 @@ NOTE: The pointer of the interpreter always starts from the first (leftmost) cel
 */
 
 export function interpreter(code: string, tape: string): string {
-    // Implement your interpreter here
+    const codeArray = code.split('');
+
+    return codeArray
+        .reduce(
+            (acc, curr, codeIndex, arr) => {
+                if (
+                    acc.tapeIndex < 0 ||
+                    acc.tapeIndex >= acc.tapeArray.length
+                ) {
+                    return acc;
+                }
+
+                switch (curr) {
+                    case '>': // move pointer right 1 cell
+                        acc.tapeIndex += 1;
+                        break;
+                    case '<': // move pointer left 1 cell
+                        acc.tapeIndex -= 1;
+                        break;
+                    case '*': // flip bit at current cell
+                        acc.tapeArray[acc.tapeIndex] =
+                            acc.tapeArray[acc.tapeIndex] === '0' ? '1' : '0';
+                        // acc.tapeIndex += 1;
+                        break;
+                    case '[': // jump past matching ] if value at current cell is 0
+                        break;
+                    case ']': // jump back to matching [ (if value at current cell is nonzero)
+                        break;
+                    default:
+                        break;
+                }
+
+                return acc;
+            },
+            { tapeArray: tape.split(''), tapeIndex: 0 },
+        )
+        .tapeArray.join('');
 }

--- a/src/esolangInturpreters/part2/index.ts
+++ b/src/esolangInturpreters/part2/index.ts
@@ -47,83 +47,8 @@ NOTE: The pointer of the interpreter always starts from the first (leftmost) cel
 
 import { SmallfuckInterpreter } from './SmallfuckInterpreter';
 
-// type MoveLeftOrRight = '>' | '<';
-// type Brackets = '[' | ']';
-// type Code = MoveLeftOrRight | '*' | Brackets;
-// type Bit = '0' | '1';
-
-// const isValidIndex = (index: number, array: unknown[]) =>
-//     index >= 0 && index < array.length;
-
-// const flipBit = (bit: Bit) => (bit === '0' ? '1' : '0');
-// const moveLeftOrRight = (command: MoveLeftOrRight) =>
-//     command === '>' ? 1 : -1;
-
 export function interpreter(code: string, tape: string): string {
     const smallfuckInterpreter = new SmallfuckInterpreter(code, tape);
 
     return smallfuckInterpreter.interpret();
-    /* const codeArray = code.split('');
-    // You may assume that all input strings for tape will be non-empty and will only contain "0"s and "1"s.
-    const tapeArray = tape.split('') as Bit[];
-
-    let stack: Code[] = [];
-    let pointer = 0;
-    let codeIndex = 0;
-
-    while (
-        isValidIndex(pointer, tapeArray) &&
-        isValidIndex(codeIndex, codeArray)
-    ) {
-        const currentBit = tapeArray[pointer];
-        const command = codeArray[codeIndex];
-
-        // Smallfuck terminates when all commands have been considered from left to right
-        if (stack.length === codeArray.length) {
-            break;
-        }
-
-        const getClosingBracketIndex = codeArray.indexOf(']', codeIndex);
-        const getOpeningBracketIndex = codeArray.lastIndexOf('[', codeIndex);
-
-        switch (command) {
-            case '>':
-            case '<':
-                // > - Move pointer to the right (by 1 cell)
-                // < - Move pointer to the left (by 1 cell)
-                pointer += moveLeftOrRight(command);
-                // stack.push(command);
-                break;
-            case '*':
-                // * - Flip the bit at the current cell
-                tapeArray[pointer] = flipBit(currentBit);
-                stack.push(command);
-                break;
-            case '[':
-                // [ - Jump past matching ] if value at current cell is 0
-                if (currentBit === '0') {
-                    const closingBracket = getClosingBracketIndex;
-                    codeIndex = closingBracket + 1;
-                }
-                stack.push(command);
-                break;
-            case ']':
-                // ] - Jump back to matching [ (if value at current cell is nonzero)
-                if (currentBit === '1') {
-                    const openingBracket = getOpeningBracketIndex;
-                    codeIndex = openingBracket;
-                    stack = stack.slice(0, openingBracket);
-                    break;
-                }
-                stack.push(command);
-                break;
-            default:
-                // Your interpreter should simply ignore any non-command characters.
-                break;
-        }
-
-        codeIndex += 1;
-    }
-
-    return tapeArray.join(''); */
 }

--- a/src/esolangInturpreters/part2/index.ts
+++ b/src/esolangInturpreters/part2/index.ts
@@ -1,0 +1,50 @@
+/*
+https://www.codewars.com/kata/esolang-interpreters-number-2-custom-smallfuck-interpreter
+
+The Language
+Smallfuck is an esoteric programming language/Esolang invented in 2002 which is a sized-down variant of the famous
+Brainfuck Esolang. Key differences include:
+    Smallfuck operates only on bits as opposed to bytes
+    It has a limited data storage which varies from implementation to implementation depending on the size of the tape
+    It does not define input or output -
+        the "input" is encoded in the initial state of the data storage (tape) and
+        the "output" should be decoded in the final state of the data storage (tape)
+
+Here are a list of commands in Smallfuck:
+
+> - Move pointer to the right (by 1 cell)
+< - Move pointer to the left (by 1 cell)
+* - Flip the bit at the current cell
+[ - Jump past matching ] if value at current cell is 0
+] - Jump back to matching [ (if value at current cell is nonzero)
+
+As opposed to Brainfuck where a program terminates only when all of the commands in the program have been considered
+(left to right), Smallfuck terminates when any of the two conditions mentioned below become true:
+    All commands have been considered from left to right
+    The pointer goes out-of-bounds (i.e. if it moves to the left of the first cell or to the right of the last cell of the tape)
+
+Smallfuck is considered to be Turing-complete if and only if it had a tape of infinite length;
+however, since the length of the tape is always defined as finite (as the interpreter cannot return a tape of infinite length),
+its computational class is of bounded-storage machines with bounded input.
+
+More information on this Esolang can be found here (http://esolangs.org/wiki/Smallfuck).
+
+The Task
+Implement a custom Smallfuck interpreter interpreter() which accepts the following arguments:
+    code - Required. The Smallfuck program to be executed, passed in as a string.
+        May contain non-command characters.
+        Your interpreter should simply ignore any non-command characters.
+    tape - Required. The initial state of the data storage (tape), passed in as a string.
+        For example, if the string "00101100" is passed in then it should translate to something of this form
+        within your interpreter: [0, 0, 1, 0, 1, 1, 0, 0].
+        You may assume that all input strings for tape will be non-empty and will only contain "0"s and "1"s.
+
+Your interpreter should return the final state of the data storage (tape) as a string in the same format that it was passed in.
+For example, if the tape in your interpreter ends up being [1, 1, 1, 1, 1] then return the string "11111".
+
+NOTE: The pointer of the interpreter always starts from the first (leftmost) cell of the tape, same as in Brainfuck.
+*/
+
+export function interpreter(code: string, tape: string): string {
+    // Implement your interpreter here
+}


### PR DESCRIPTION
# [Esolang Interpreters #2 - Custom Smallfuck Interpreter](https://www.codewars.com/kata/esolang-interpreters-number-2-custom-smallfuck-interpreter)

## Notes
originally done using functional programming (see https://github.com/snelling-a/codewars/pull/62/commits/60d828bb76ad9a489f04548c612bd217e6ea131b)

refactored using OOP. slightly slower

## Checklist
- [x] url and description in `index` file (see below)
- [x] tested
- [x] PR labeled with difficulty


#### Example
```typescript
/*
https://www.codewars.com/kata/<some numbers>

Write function that meets these requirements...
 */
```
